### PR TITLE
missing pagination for catalog

### DIFF
--- a/gitlab_registry_usage/registry/low_level_api.py
+++ b/gitlab_registry_usage/registry/low_level_api.py
@@ -61,7 +61,7 @@ def get_repository_auth_token(gitlab_url: str, username: str, password: str, rep
 
 
 def get_registry_catalog(registry_url: str, auth_token: str) -> List[str]:
-    catalog_url = '{base}v2/_catalog'.format(base=registry_url)
+    catalog_url = '{base}v2/_catalog?n={size}'.format(base=registry_url, size=16384)
     response = requests.get(catalog_url, headers={'Authorization': 'Bearer ' + auth_token})
     if response.status_code != 200:
         raise CatalogReadError

--- a/gitlab_registry_usage/registry/low_level_api.py
+++ b/gitlab_registry_usage/registry/low_level_api.py
@@ -77,7 +77,7 @@ def get_registry_catalog(registry_url: str, auth_token: str) -> List[str]:
 
 
 def get_repository_tags(registry_url: str, auth_token: str, repository: str) -> List[str]:
-    repo_tags_url = '{base}v2/{repository}/tags/list'.format(base=registry_url, repository=repository)
+    repo_tags_url = '{base}v2/{repository}/tags/list?n={size}'.format(base=registry_url, repository=repository, size=16384)
     response = requests.get(repo_tags_url, headers={'Authorization': 'Bearer ' + auth_token})
     if response.status_code != 200:
         raise TagsReadError


### PR DESCRIPTION
[get_registry_catalog](https://github.com/sciapp/gitlab-registry-usage/blob/v0.2.2/gitlab_registry_usage/registry/low_level_api.py#L63-L76) doesn't seem to handle paging. and default paging is 20 or 50 items, meaning the whole registry is not processed.

this adds simple workaround, fetch 16k items, which should be enough for everybody ;)

api docs: https://docs.docker.com/registry/spec/api/#listing-repositories

> **PAGINATION**
> Paginated catalog results can be retrieved by adding an n parameter to the request URL,
> declaring that the response should be limited to n results. Starting a paginated flow begins as follows:
>
> `GET /v2/_catalog?n=<integer>`