### PR TITLE
Size of 16384 seems invalid in recent gitlab registries. Pagination is not used anyway

### DIFF
--- a/gitlab_registry_usage/registry/low_level_api.py
+++ b/gitlab_registry_usage/registry/low_level_api.py
@@ -61,7 +61,7 @@ def get_repository_auth_token(gitlab_url: str, username: str, password: str, rep
 
 
 def get_registry_catalog(registry_url: str, auth_token: str) -> List[str]:
-    catalog_url = "{base}v2/_catalog?n={size}".format(base=registry_url, size=16384)
+    catalog_url = "{base}v2/_catalog".format(base=registry_url)
     response = requests.get(catalog_url, headers={"Authorization": "Bearer " + auth_token})
     if response.status_code != 200:
         raise CatalogReadError
@@ -77,8 +77,8 @@ def get_registry_catalog(registry_url: str, auth_token: str) -> List[str]:
 
 
 def get_repository_tags(registry_url: str, auth_token: str, repository: str) -> List[str]:
-    repo_tags_url = "{base}v2/{repository}/tags/list?n={size}".format(
-        base=registry_url, repository=repository, size=16384
+    repo_tags_url = "{base}v2/{repository}/tags/list".format(
+        base=registry_url, repository=repository
     )
     response = requests.get(repo_tags_url, headers={"Authorization": "Bearer " + auth_token})
     if response.status_code != 200:


### PR DESCRIPTION
On my self-hosted community edition gitlab, the catalog calls answers http 400 with size set to 16384.

Using this arbitrary size seems wrong to me anyway as pagination is not used here.
